### PR TITLE
chore: Update Travis config - drop support for testing against nodejs v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 node_js:
-  - 4
   - 6 
   - 7
+  - 8
+  - 9
+  - 10
 before_install:
   - npm install -g npm@3
   - npm config set loglevel error


### PR DESCRIPTION
Update travis configuration for running tests against different versions of nodejs

- Removed support for testing against nodejs v4.
  - 1bdeece6ea81021d6b4895865cdb251b89657946 upgraded mocha to v6.
  - As of mocha v6, nodejs v4 is [no longer supported](https://mochajs.org/#installation).
- Add support for testing against nodejs v8
- Add support for testing against nodejs v9
- Add support for testing against nodejs v10