### PR TITLE
dont use ES6 syntax in grammar

### DIFF
--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -191,7 +191,7 @@ geometry_point
       )*
     end_object
     {
-      var result = distance;
+      var result = distance || {};
       distance.$geometry = geometry;
       return result;
     }

--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -183,14 +183,17 @@ geometry_point
       distance:(
         value_separator quotation_mark operator:distance_operator quotation_mark
         name_separator value:number_positive
-        { return { [operator]: value }; }
+        { 
+          var result = {};
+          result[operator] = value;
+          return result;
+        }
       )*
     end_object
     {
-      return {
-        "$geometry": geometry,
-        ...(distance ? distance : {})
-      };
+      var result = distance;
+      distance.$geometry = geometry;
+      return result;
     }
 
 geometry_type


### PR DESCRIPTION
In c8b9e2 we removed transpilation to ES5, which broke Charts e2e tests. There are only two places where we use ES6 syntax. This PR replaces them with ES5 compatible code. 

To test locally for Charts, you can `yarn link` this module, then `yarn link mongodb-language-model` from the charts root folder. Then build and run the e2e tests. Before this change, they would fail on the very first test with a blank screen and error `Uncaught SyntaxError: Unexpected token ...` in the dev console.

This PR can be merged and released as 1.6.1 after Charts and Compass have reviewed and approved.
